### PR TITLE
Updating to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: "s3 secret key"
     required: true
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
Due to GitHub deprecating Node.js 12 actions, this action needs to be updated to support Node.js 16.  Currently GitHub shares the following warning text: 

```Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: s3-actions/s3cmd@v1.2.0```
