### PR TITLE
Update to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     description: "s3 secret key"
     required: true
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Due to GitHub deprecating Node.js 16 actions, this action needs to be updated to support Node.js 20. Currently GitHub shares the following warning text:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: s3-actions/s3cmd@v1.5.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```