### PR TITLE
feat: add support for hetnzer cloud s3 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ Currently the below providers are supported, but it could be used with other pro
 - Cloudflare
 - Vultr
 - CleverCloud
+- Hetzner Cloud
 
 ## Inputs
 
 ### `provider`
 
-**Not Required** The s3 provider to use. Defaults to Linode. AWS, Linode, DigitalOcean, Scaleway, Cloudflare, Vultr, CleverCloud are supported.
+**Not Required** The s3 provider to use. Defaults to Linode. AWS, Linode, DigitalOcean, Scaleway, Cloudflare, Vultr, CleverCloud, Hetzner Cloud are supported.
 
 ### `secret_key`
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -24922,7 +24922,7 @@ exports["default"] = _default;
 const defaults = __nccwpck_require__(724)
 
 const providers = {
-  aws: ({ region = 'US', access_key = '', secret_key = ''}) => ({
+  aws: ({ region = 'US', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: 's3.amazonaws.com',
     host_bucket: '%(bucket)s.s3.amazonaws.com',
@@ -24930,7 +24930,7 @@ const providers = {
     access_key,
     secret_key,
   }),
-  digitalocean: ({ region = 'nyc3', access_key = '', secret_key = ''}) => ({
+  digitalocean: ({ region = 'nyc3', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: `${region}.digitaloceanspaces.com`,
     host_bucket: `%(bucket)s.${region}.digitaloceanspaces.com`,
@@ -24954,7 +24954,7 @@ const providers = {
     access_key,
     secret_key,
   }),
-  cloudflare: ({ account_id = '', region='auto', access_key = '', secret_key = '' }) => ({
+  cloudflare: ({ account_id = '', region = 'auto', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: `${account_id}.r2.cloudflarestorage.com`,
     host_bucket: '',
@@ -24962,7 +24962,7 @@ const providers = {
     access_key,
     secret_key,
   }),
-  vultr: ({ region = 'ewr1', access_key = '', secret_key = ''}) => ({
+  vultr: ({ region = 'ewr1', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: `${region}.vultrobjects.com`,
     host_bucket: `%(bucket)s.${region}.vultrobjects.com`,
@@ -24978,6 +24978,14 @@ const providers = {
     access_key,
     secret_key,
   }),
+  hcloud: ({ region = 'fsn1', access_key = '', secret_key = '' }) => ({
+    bucket_location: region,
+    host_base: `fsn1.your-objectstorage.com`,
+    host_bucket: `%(bucket)s.fsn1.your-objectstorage.com`,
+    website_endpoint: '',
+    access_key,
+    secret_key,
+  })
 }
 
 const makeConf = (provider) => {

--- a/src/providers.js
+++ b/src/providers.js
@@ -1,7 +1,7 @@
 const defaults = require('./defaults.json')
 
 const providers = {
-  aws: ({ region = 'US', access_key = '', secret_key = ''}) => ({
+  aws: ({ region = 'US', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: 's3.amazonaws.com',
     host_bucket: '%(bucket)s.s3.amazonaws.com',
@@ -9,7 +9,7 @@ const providers = {
     access_key,
     secret_key,
   }),
-  digitalocean: ({ region = 'nyc3', access_key = '', secret_key = ''}) => ({
+  digitalocean: ({ region = 'nyc3', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: `${region}.digitaloceanspaces.com`,
     host_bucket: `%(bucket)s.${region}.digitaloceanspaces.com`,
@@ -33,7 +33,7 @@ const providers = {
     access_key,
     secret_key,
   }),
-  cloudflare: ({ account_id = '', region='auto', access_key = '', secret_key = '' }) => ({
+  cloudflare: ({ account_id = '', region = 'auto', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: `${account_id}.r2.cloudflarestorage.com`,
     host_bucket: '',
@@ -41,7 +41,7 @@ const providers = {
     access_key,
     secret_key,
   }),
-  vultr: ({ region = 'ewr1', access_key = '', secret_key = ''}) => ({
+  vultr: ({ region = 'ewr1', access_key = '', secret_key = '' }) => ({
     bucket_location: region,
     host_base: `${region}.vultrobjects.com`,
     host_bucket: `%(bucket)s.${region}.vultrobjects.com`,
@@ -57,6 +57,14 @@ const providers = {
     access_key,
     secret_key,
   }),
+  hcloud: ({ region = 'fsn1', access_key = '', secret_key = '' }) => ({
+    bucket_location: region,
+    host_base: `fsn1.your-objectstorage.com`,
+    host_bucket: `%(bucket)s.fsn1.your-objectstorage.com`,
+    website_endpoint: '',
+    access_key,
+    secret_key,
+  })
 }
 
 const makeConf = (provider) => {

--- a/src/test.js
+++ b/src/test.js
@@ -65,3 +65,13 @@ const clevercloudConf = makeConf(providers.clevercloud({
 for (const line of clevercloudConf) {
   clevercloudWriter.write(line + '\r\n')
 }
+
+const hcloudWriter = createWriteStream('assets/test-results/hcloud')
+const hcloudConf = makeConf(providers.hcloud({
+  access_key: 'top-secret',
+  secret_key: 'more secret'
+}))
+
+for (const line of hcloudConf) {
+  hcloudWriter.write(line + '\r\n')
+}


### PR DESCRIPTION
This adds support for Hetzner Cloud as provider for object storage.
 
Hcloud S3 is currently in beta and not yet officially announced. However there are already official [docs](https://docs.hetzner.com/storage/object-storage/) about it and it's listed as an entry in the Hcloud console. I received beta access this week and used their S3 together with this action [here](https://github.com/the-technat/tevbox/blob/main/.github/workflows/hcloud.yml#L67-L74). Since I had to workaround the missing provider I thought I'll try and contribute it here.

As region, Hetzner currently only provides `fsn1`.

Let me know what you think.

